### PR TITLE
add Feature/game tab change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,8 @@ import PersonalInfoPage from "./page/PersonalInfoPage";
 import EditPersonalInfoPage from "./page/EditPersonalInfoPage";
 import SearchResultsPage from "./page/SearchResultsPage";
 import WritePostPage from "./page/WritePostPage";
+import WikiHistoryPage from "./page/WikiHistoryPage";
+import WikiHistoryContentPage from "./page/WikiHistoryContentPage";
 
 const App = () => {
   return (
@@ -39,6 +41,8 @@ const App = () => {
             <Route path="/ReadPostPage" element={<ReadPostPage />} />
             <Route path="/SearchResultsPage" element={<SearchResultsPage />} />
             <Route path="/WritePostPage" element={<WritePostPage />} />
+            <Route path="/editHistory" element={<WikiHistoryPage />} />
+            <Route path="/editContent" element={<WikiHistoryContentPage />} />
           </Routes>
         </BrowserRouter>
       </RecoilRoot>

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ const App = () => {
             <Route path="/SearchResultsPage" element={<SearchResultsPage />} />
             <Route path="/WritePostPage" element={<WritePostPage />} />
             <Route path="/game/:idx/history" element={<WikiHistoryPage />} />
-            <Route path="/editContent" element={<WikiHistoryContentPage />} />
+            <Route path="/game/:idx/history/:idx" element={<WikiHistoryContentPage />} />
           </Routes>
         </BrowserRouter>
       </RecoilRoot>

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,7 @@ const App = () => {
             <Route path="/ReadPostPage" element={<ReadPostPage />} />
             <Route path="/SearchResultsPage" element={<SearchResultsPage />} />
             <Route path="/WritePostPage" element={<WritePostPage />} />
-            <Route path="/editHistory" element={<WikiHistoryPage />} />
+            <Route path="/game/:idx/history" element={<WikiHistoryPage />} />
             <Route path="/editContent" element={<WikiHistoryContentPage />} />
           </Routes>
         </BrowserRouter>

--- a/src/component/SwitchTabItem.js
+++ b/src/component/SwitchTabItem.js
@@ -29,7 +29,11 @@ const SwitchTabItem = (props) => {
           $fontSize="large"
           $flex="h_center_center"
           key={elem}
-          onClick={() => BtnClickEvent(elem)}
+          onClick={() => {
+            BtnClickEvent(elem);
+            props.onClick(elem);
+            console.log(elem);
+          }}
         >
           <Span $color={tab === elem ? "white" : "black"} $fontSize="12px">
             {elem}

--- a/src/component/SwitchTabItem.js
+++ b/src/component/SwitchTabItem.js
@@ -32,7 +32,6 @@ const SwitchTabItem = (props) => {
           onClick={() => {
             BtnClickEvent(elem);
             props.onClick(elem);
-            console.log(elem);
           }}
         >
           <Span $color={tab === elem ? "white" : "black"} $fontSize="12px">

--- a/src/container/inGamePage/GameContentContainer.js
+++ b/src/container/inGamePage/GameContentContainer.js
@@ -27,14 +27,9 @@ const GameContentContainer = () => {
   const navToggle = useRecoilValue(navToggleAtom);
 
   const [tabBtnValue, setTabBtnValue] = useState(BtnText[0]);
-  const [historyBtn, setHistoryBtn] = useState(false);
-  const [editBtn, setEditBtn] = useState(false);
-  const [backToWikiBtn, setBackToWikiBtn] = useState(false);
 
   const switchTabEvent = (btnText) => {
     setTabBtnValue(btnText);
-    setHistoryBtn(false);
-    setEditBtn(false);
   };
 
   return (
@@ -50,22 +45,7 @@ const GameContentContainer = () => {
       />
       <Article $flex="h_center_center" $backgroundColor="major" $width="100%" $padding="50px">
         {tabBtnValue === "커뮤니티" && <CommunityContainer />}
-        {tabBtnValue === "위키" && !historyBtn && (
-          <WikiContainer
-            historyBtn={historyBtn}
-            setHistoryBtn={setHistoryBtn}
-            editBtn={editBtn}
-            setEditBtn={setEditBtn}
-          />
-        )}
-        {tabBtnValue !== "커뮤니티" && historyBtn && !editBtn && (
-          <WikiHistoryListContainer
-            backToWikiBtn={backToWikiBtn}
-            setBackToWikiBtn={setBackToWikiBtn}
-          />
-        )}
-        {tabBtnValue !== "커뮤니티" && editBtn && !historyBtn && <WikiEditContainer />}
-        {backToWikiBtn && <WikiContainer />}
+        {tabBtnValue === "위키" && <WikiContainer />}
       </Article>
     </GameContentLayout>
   );

--- a/src/container/inGamePage/GameContentContainer.js
+++ b/src/container/inGamePage/GameContentContainer.js
@@ -11,8 +11,6 @@ import bannerImg from "../../img/bannerImg.svg";
 import SwitchTabItem from "../../component/SwitchTabItem";
 import CommunityContainer from "../inCommunityPage/CommunityContainer";
 import WikiContainer from "../inWikiComponent/WikiContainer";
-import WikiHistoryListContainer from "../inWikiComponent/WikiHistoryListContainer";
-import WikiEditContainer from "../WikiEditContainer";
 
 const GameContentLayout = styled(Section)`
   width: calc(100vw - 120px);

--- a/src/container/inWikiComponent/WikiContainer.js
+++ b/src/container/inWikiComponent/WikiContainer.js
@@ -10,6 +10,8 @@ import putByUserImg from "../../img/putByUserImg.svg";
 import historyImg from "../../img/historyImg.svg";
 import editImg from "../../img/editImg.svg";
 
+import { Link } from "react-router-dom";
+
 const MainContentLayout = styled(Div)`
   line-height: 30px;
 `;
@@ -31,14 +33,7 @@ const ImgByUser = styled(Img)`
   width: 100%;
 `;
 
-const WikiContainer = ({ historyBtn, setHistoryBtn, editBtn, setEditBtn }) => {
-  const clickHistoryBtnEvent = () => {
-    setHistoryBtn(!historyBtn);
-  };
-  const clickEditBtnEvent = () => {
-    setHistoryBtn(!editBtn);
-  };
-
+const WikiContainer = () => {
   return (
     <Section $backgroundColor="white" $width="100%" $height="80%" $padding="40px">
       <Article $width="100%">
@@ -47,24 +42,22 @@ const WikiContainer = ({ historyBtn, setHistoryBtn, editBtn, setEditBtn }) => {
             리그오브레전드(League of legends)
           </GameTitleLayout>
           <Div $flex="h_between_start" $width="30%">
-            <ImgTextBtnUtil
-              img={historyImg}
-              text={"HISTORY"}
-              color={"major"}
-              backgroundColor={"white"}
-              historyBtn={historyBtn}
-              setHistoryBtn={setHistoryBtn}
-              onClick={clickHistoryBtnEvent}
-            />
-            <ImgTextBtnUtil
-              img={editImg}
-              text={"EDIT"}
-              color={"major"}
-              backgroundColor={"white"}
-              editBtn={editBtn}
-              setEditBtn={setEditBtn}
-              onClick={clickEditBtnEvent}
-            />
+            <Link to="./history">
+              <ImgTextBtnUtil
+                img={historyImg}
+                text={"HISTORY"}
+                color={"major"}
+                backgroundColor={"white"}
+              />
+            </Link>
+            <Link to="./edit">
+              <ImgTextBtnUtil
+                img={editImg}
+                text={"EDIT"}
+                color={"major"}
+                backgroundColor={"white"}
+              />
+            </Link>
           </Div>
         </Div>
         <MainContentLayout $flex="v_start_center" $width="100%" $margin="20px 0 0 0">

--- a/src/container/inWikiComponent/WikiHistoryContentContainer.js
+++ b/src/container/inWikiComponent/WikiHistoryContentContainer.js
@@ -1,39 +1,95 @@
-import React from "react";
+import { React, useState } from "react";
+
+import { Link, useNavigate } from "react-router-dom";
+
+import { useRecoilValue } from "recoil";
+import navToggleAtom from "../../recoil/navToggleAtom";
 
 import { styled } from "styled-components";
+import { Img } from "../../style/ImgStyle";
 import { Article, Section, Div } from "../../style/LayoutStyle";
 import { H1, P } from "../../style/TextStyle";
 
 import backImg from "../../img/backImg.svg";
 import ImgTextBtnUtil from "../../util/ImgTextBtnUtil";
+import bannerImg from "../../img/bannerImg.svg";
+import SwitchTabItem from "../../component/SwitchTabItem";
 
 const GameTitleLayout = styled(H1)`
   font-size: 45px;
 `;
+const HistoryWriterLayout = styled(P)``;
 const HistoryContentLayout = styled(P)`
   line-height: 30px;
 `;
+const GameContentLayout = styled(Section)`
+  width: calc(100vw - 120px);
+  transition: padding 0.1s ease;
+`;
+const BannerImg = styled(Img)`
+  width: 100%;
+`;
 
-const WikiHistoryListContainer = () => {
+const WikiHistoryContentContainer = () => {
+  const navToggle = useRecoilValue(navToggleAtom);
+  const navigate = useNavigate();
+
+  const BtnText = ["커뮤니티", "위키"];
+  const [tabBtnValue, setTabBtnValue] = useState(BtnText[1]);
+
   return (
-    <Section $backgroundColor="white" $width="100%" $height="80%" $padding="40px">
-      <Article $width="100%">
-        <Div $flex="h_between_start" $width="100%" $margin="0 0 20px 0">
-          <GameTitleLayout $width="60%" $fontWeight="bold">
-            리그오브레전드(League of legends)
-          </GameTitleLayout>
-          <Div $flex="h_end_start" $width="30%">
-            <ImgTextBtnUtil img={backImg} text={"BACK"} color={"major"} />
-          </Div>
-        </Div>
-        <HistoryContentLayout $flex="v_center_start" $width="100%">
-          리그 오브 레전드에서는 1년이 1시즌이다. 이는 다른 게임들과 비교하면 긴 기간이다. 배치를
-          받은 후 시즌이 끝날 때까지 랭크를 올리는 것이 랭크 게임의 주 플레이 목적으로, 시즌 종료후
-          다음 시즌이 시작되면 다시 배치 게임을 치러야 한다.
-        </HistoryContentLayout>
+    <GameContentLayout $flex="v_center_center" $padding={navToggle && "0 0 0 250px"}>
+      <Div $width="100%">
+        <BannerImg src={bannerImg} />
+      </Div>
+      <SwitchTabItem
+        {...{ BtnText }}
+        tab={tabBtnValue}
+        setTab={setTabBtnValue}
+        onClick={(tabText) => {
+          setTabBtnValue(tabText);
+          if (tabText === "커뮤니티") {
+            navigate("/game/:idx");
+          }
+        }}
+      />
+      <Article $flex="h_center_center" $backgroundColor="major" $width="100%" $padding="50px">
+        <Section $backgroundColor="white" $width="100%" $height="80%" $padding="40px">
+          <Article $width="100%">
+            <Div $flex="h_between_start" $width="100%" $margin="0 0 20px 0">
+              <GameTitleLayout $width="60%" $fontWeight="bold">
+                리그오브레전드(League of legends)
+              </GameTitleLayout>
+              <Link to={`../game/:idx/history`}>
+                <Div $flex="h_end_start" $width="30%">
+                  <ImgTextBtnUtil
+                    img={backImg}
+                    text={"BACK"}
+                    color={"major"}
+                    backgroundColor={"white"}
+                  />
+                </Div>
+              </Link>
+            </Div>
+            <HistoryWriterLayout
+              $flex="v_center_start"
+              $width="100%"
+              $fontWeight="bold"
+              $fontSize="large"
+              $margin="0 0 20px 0"
+            >
+              2024-02-29 16:51:41 쪼경은
+            </HistoryWriterLayout>
+            <HistoryContentLayout $flex="v_center_start" $width="100%">
+              리그 오브 레전드에서는 1년이 1시즌이다. 이는 다른 게임들과 비교하면 긴 기간이다.
+              배치를 받은 후 시즌이 끝날 때까지 랭크를 올리는 것이 랭크 게임의 주 플레이 목적으로,
+              시즌 종료후 다음 시즌이 시작되면 다시 배치 게임을 치러야 한다.
+            </HistoryContentLayout>
+          </Article>
+        </Section>
       </Article>
-    </Section>
+    </GameContentLayout>
   );
 };
 
-export default WikiHistoryListContainer;
+export default WikiHistoryContentContainer;

--- a/src/container/inWikiComponent/WikiHistoryContentContainer.js
+++ b/src/container/inWikiComponent/WikiHistoryContentContainer.js
@@ -1,20 +1,17 @@
 import React from "react";
 
 import { styled } from "styled-components";
-import { Article, Section, Div } from "../style/LayoutStyle";
-import { H1, P } from "../style/TextStyle";
+import { Article, Section, Div } from "../../style/LayoutStyle";
+import { H1, P } from "../../style/TextStyle";
 
-import backImg from "../img/backImg.svg";
-import ImgTextBtnUtil from "../util/ImgTextBtnUtil";
+import backImg from "../../img/backImg.svg";
+import ImgTextBtnUtil from "../../util/ImgTextBtnUtil";
 
 const GameTitleLayout = styled(H1)`
   font-size: 45px;
 `;
 const HistoryContentLayout = styled(P)`
   line-height: 30px;
-`;
-const GameTitleLayout = styled(H1)`
-  font-size: 45px;
 `;
 
 const WikiHistoryListContainer = () => {
@@ -33,11 +30,7 @@ const WikiHistoryListContainer = () => {
             <ImgTextBtnUtil img={backImg} text={"BACK"} color={"major"} />
           </Div>
         </Div>
-        <HistoryContentLayout $flex="v_center_start" $width="100%">
-          {WikiHistoryDummyData.map((elem) => {
-            return <li>{`${elem.content}`}</li>;
-          })}
-        </HistoryContentLayout>
+        <HistoryContentLayout $flex="v_center_start" $width="100%"></HistoryContentLayout>
       </Article>
     </Section>
   );

--- a/src/container/inWikiComponent/WikiHistoryContentContainer.js
+++ b/src/container/inWikiComponent/WikiHistoryContentContainer.js
@@ -15,10 +15,6 @@ const HistoryContentLayout = styled(P)`
 `;
 
 const WikiHistoryListContainer = () => {
-  const WikiHistoryDummyData = [
-    "리그 오브 레전드에서는 1년이 1시즌이다. 이는 다른 게임들과 비교하면 긴 기간이다. 배치를 받은 후 시즌이 끝날 때까지 랭크를 올리는 것이 랭크 게임의 주 플레이 목적으로, 시즌 종료후 다음 시즌이 시작되면 다시 배치 게임을 치러야 한다.",
-  ];
-
   return (
     <Section $backgroundColor="white" $width="100%" $height="80%" $padding="40px">
       <Article $width="100%">
@@ -30,7 +26,11 @@ const WikiHistoryListContainer = () => {
             <ImgTextBtnUtil img={backImg} text={"BACK"} color={"major"} />
           </Div>
         </Div>
-        <HistoryContentLayout $flex="v_center_start" $width="100%"></HistoryContentLayout>
+        <HistoryContentLayout $flex="v_center_start" $width="100%">
+          리그 오브 레전드에서는 1년이 1시즌이다. 이는 다른 게임들과 비교하면 긴 기간이다. 배치를
+          받은 후 시즌이 끝날 때까지 랭크를 올리는 것이 랭크 게임의 주 플레이 목적으로, 시즌 종료후
+          다음 시즌이 시작되면 다시 배치 게임을 치러야 한다.
+        </HistoryContentLayout>
       </Article>
     </Section>
   );

--- a/src/container/inWikiComponent/WikiHistoryListContainer.js
+++ b/src/container/inWikiComponent/WikiHistoryListContainer.js
@@ -18,7 +18,7 @@ import SwitchTabItem from "../../component/SwitchTabItem";
 const GameTitleLayout = styled(H1)`
   font-size: 45px;
 `;
-const HistoryContentLayout = styled(P)`
+const HistoryListLayout = styled(P)`
   line-height: 30px;
 `;
 const GameContentLayout = styled(Section)`
@@ -38,23 +38,23 @@ const WikiHistoryListContainer = () => {
 
   const WikiHistoryListDummyData = [
     {
-      idx: "history_11",
+      idx: "history_1",
       content: "2024-02-29 16:58:36 쩡태은",
     },
     {
-      idx: "history_10",
+      idx: "history_2",
       content: "2024-02-29 16:54:11 김기쭈",
     },
     {
-      idx: "history_9",
+      idx: "history_3",
       content: "2024-02-29 16:51:41 쪼경은",
     },
     {
-      idx: "history_8",
+      idx: "history_4",
       content: "2024-02-29 16:39:44 최민썩",
     },
     {
-      idx: "history_7",
+      idx: "history_5",
       content: "2024-02-28 21:11:25 뱅준연",
     },
     {
@@ -62,23 +62,23 @@ const WikiHistoryListContainer = () => {
       content: "2024-02-28 21:03:15 박해쭈",
     },
     {
-      idx: "history_5",
+      idx: "history_7",
       content: "2024-02-29 16:58:36 쩡태은",
     },
     {
-      idx: "history_4",
+      idx: "history_8",
       content: "2024-02-28 21:02:01 김기쭈",
     },
     {
-      idx: "history_3",
+      idx: "history_9",
       content: "2024-02-28 20:58:27 쪼경은",
     },
     {
-      idx: "history_2",
+      idx: "history_10",
       content: "2024-02-24 11:58:27 최민썩",
     },
     {
-      idx: "history_1",
+      idx: "history_11",
       content: "2024-02-24 09:28:30 뱅준연",
     },
   ];
@@ -96,7 +96,6 @@ const WikiHistoryListContainer = () => {
           setTabBtnValue(tabText);
           if (tabText === "커뮤니티") {
             navigate("/game/:idx");
-            console.log("커뮤니티로 이동할 거야");
           }
         }}
       />
@@ -118,7 +117,7 @@ const WikiHistoryListContainer = () => {
                 </Div>
               </Link>
             </Div>
-            <HistoryContentLayout $flex="v_center_start" $width="100%">
+            <HistoryListLayout $flex="v_center_start" $width="100%">
               {WikiHistoryListDummyData.map((elem) => {
                 return (
                   <Link key={`${elem.idx}`} to={`./${elem.idx}`}>
@@ -126,7 +125,7 @@ const WikiHistoryListContainer = () => {
                   </Link>
                 );
               })}
-            </HistoryContentLayout>
+            </HistoryListLayout>
           </Article>
         </Section>
       </Article>

--- a/src/container/inWikiComponent/WikiHistoryListContainer.js
+++ b/src/container/inWikiComponent/WikiHistoryListContainer.js
@@ -1,10 +1,14 @@
 import React from "react";
+
 import { styled } from "styled-components";
 import { Article, Section, Div } from "../../style/LayoutStyle";
 import { H1, P } from "../../style/TextStyle";
 
 import backImg from "../../img/backImg.svg";
 import ImgTextBtnUtil from "../../util/ImgTextBtnUtil";
+import WikiHistoryContainer from "./WikiHistoryContentContainer";
+
+import { Link } from "react-router-dom";
 
 const GameTitleLayout = styled(H1)`
   font-size: 45px;
@@ -13,57 +17,53 @@ const HistoryContentLayout = styled(P)`
   line-height: 30px;
 `;
 
-const WikiHistoryListContainer = ({ backToWikiBtn, setBackToWikiBtn }) => {
+const WikiHistoryListContainer = () => {
   const WikiHistoryListDummyData = [
     {
-      id: "history_11",
+      idx: "history_11",
       content: "2024-02-29 16:58:36 쩡태은",
     },
     {
-      id: "history_10",
+      idx: "history_10",
       content: "2024-02-29 16:54:11 김기쭈",
     },
     {
-      id: "history_9",
+      idx: "history_9",
       content: "2024-02-29 16:51:41 쪼경은",
     },
     {
-      id: "history_8",
+      idx: "history_8",
       content: "2024-02-29 16:39:44 최민썩",
     },
     {
-      id: "history_7",
+      idx: "history_7",
       content: "2024-02-28 21:11:25 뱅준연",
     },
     {
-      id: "history_6",
+      idx: "history_6",
       content: "2024-02-28 21:03:15 박해쭈",
     },
     {
-      id: "history_5",
+      idx: "history_5",
       content: "2024-02-29 16:58:36 쩡태은",
     },
     {
-      id: "history_4",
+      idx: "history_4",
       content: "2024-02-28 21:02:01 김기쭈",
     },
     {
-      id: "history_3",
+      idx: "history_3",
       content: "2024-02-28 20:58:27 쪼경은",
     },
     {
-      id: "history_2",
+      idx: "history_2",
       content: "2024-02-24 11:58:27 최민썩",
     },
     {
-      id: "history_1",
+      idx: "history_1",
       content: "2024-02-24 09:28:30 뱅준연",
     },
   ];
-  const clickBackToWikiBtn = () => {
-    setBackToWikiBtn(!backToWikiBtn);
-  };
-  console.log(backToWikiBtn);
 
   return (
     <Section $backgroundColor="white" $width="100%" $height="80%" $padding="40px">
@@ -72,21 +72,24 @@ const WikiHistoryListContainer = ({ backToWikiBtn, setBackToWikiBtn }) => {
           <GameTitleLayout $width="60%" $fontWeight="bold">
             리그오브레전드(League of legends)
           </GameTitleLayout>
-          <Div $flex="h_end_start" $width="30%">
-            <ImgTextBtnUtil
-              img={backImg}
-              text={"BACK"}
-              color={"major"}
-              backgroundColor={"white"}
-              backToWikiBtn={backToWikiBtn}
-              setBackToWikiBtn={setBackToWikiBtn}
-              onClick={clickBackToWikiBtn}
-            />
-          </Div>
+          <Link to="../">
+            <Div $flex="h_end_start" $width="30%">
+              <ImgTextBtnUtil
+                img={backImg}
+                text={"BACK"}
+                color={"major"}
+                backgroundColor={"white"}
+              />
+            </Div>
+          </Link>
         </Div>
         <HistoryContentLayout $flex="v_center_start" $width="100%">
           {WikiHistoryListDummyData.map((elem) => {
-            return <li>{`${elem.content}`}</li>;
+            return (
+              <Link key={`${elem.idx}`} to={`./${elem.idx}`}>
+                <WikiHistoryContainer key={elem.idx} data={elem} />
+              </Link>
+            );
           })}
         </HistoryContentLayout>
       </Article>

--- a/src/container/inWikiComponent/WikiHistoryListContainer.js
+++ b/src/container/inWikiComponent/WikiHistoryListContainer.js
@@ -1,14 +1,19 @@
-import React from "react";
+import { React, useState } from "react";
+
+import { Link, useNavigate } from "react-router-dom";
+
+import { useRecoilValue } from "recoil";
+import navToggleAtom from "../../recoil/navToggleAtom";
 
 import { styled } from "styled-components";
+import { Img } from "../../style/ImgStyle";
 import { Article, Section, Div } from "../../style/LayoutStyle";
 import { H1, P } from "../../style/TextStyle";
 
 import backImg from "../../img/backImg.svg";
 import ImgTextBtnUtil from "../../util/ImgTextBtnUtil";
-import WikiHistoryContainer from "./WikiHistoryContentContainer";
-
-import { Link } from "react-router-dom";
+import bannerImg from "../../img/bannerImg.svg";
+import SwitchTabItem from "../../component/SwitchTabItem";
 
 const GameTitleLayout = styled(H1)`
   font-size: 45px;
@@ -16,8 +21,21 @@ const GameTitleLayout = styled(H1)`
 const HistoryContentLayout = styled(P)`
   line-height: 30px;
 `;
+const GameContentLayout = styled(Section)`
+  width: calc(100vw - 120px);
+  transition: padding 0.1s ease;
+`;
+const BannerImg = styled(Img)`
+  width: 100%;
+`;
 
 const WikiHistoryListContainer = () => {
+  const navToggle = useRecoilValue(navToggleAtom);
+  const navigate = useNavigate();
+
+  const BtnText = ["커뮤니티", "위키"];
+  const [tabBtnValue, setTabBtnValue] = useState(BtnText[1]);
+
   const WikiHistoryListDummyData = [
     {
       idx: "history_11",
@@ -66,34 +84,53 @@ const WikiHistoryListContainer = () => {
   ];
 
   return (
-    <Section $backgroundColor="white" $width="100%" $height="80%" $padding="40px">
-      <Article $width="100%">
-        <Div $flex="h_between_start" $width="100%" $margin="0 0 20px 0">
-          <GameTitleLayout $width="60%" $fontWeight="bold">
-            리그오브레전드(League of legends)
-          </GameTitleLayout>
-          <Link to="../">
-            <Div $flex="h_end_start" $width="30%">
-              <ImgTextBtnUtil
-                img={backImg}
-                text={"BACK"}
-                color={"major"}
-                backgroundColor={"white"}
-              />
-            </Div>
-          </Link>
-        </Div>
-        <HistoryContentLayout $flex="v_center_start" $width="100%">
-          {WikiHistoryListDummyData.map((elem) => {
-            return (
-              <Link key={`${elem.idx}`} to={`./${elem.idx}`}>
-                <WikiHistoryContainer key={elem.idx} data={elem} />
+    <GameContentLayout $flex="v_center_center" $padding={navToggle && "0 0 0 250px"}>
+      <Div $width="100%">
+        <BannerImg src={bannerImg} />
+      </Div>
+      <SwitchTabItem
+        {...{ BtnText }}
+        tab={tabBtnValue}
+        setTab={setTabBtnValue}
+        onClick={(tabText) => {
+          setTabBtnValue(tabText);
+          if (tabText === "커뮤니티") {
+            navigate("/game/:idx");
+            console.log("커뮤니티로 이동할 거야");
+          }
+        }}
+      />
+      <Article $flex="h_center_center" $backgroundColor="major" $width="100%" $padding="50px">
+        <Section $backgroundColor="white" $width="100%" $height="80%" $padding="40px">
+          <Article $width="100%">
+            <Div $flex="h_between_start" $width="100%" $margin="0 0 20px 0">
+              <GameTitleLayout $width="60%" $fontWeight="bold">
+                리그오브레전드(League of legends)
+              </GameTitleLayout>
+              <Link to={`../game/:idx`}>
+                <Div $flex="h_end_start" $width="30%">
+                  <ImgTextBtnUtil
+                    img={backImg}
+                    text={"BACK"}
+                    color={"major"}
+                    backgroundColor={"white"}
+                  />
+                </Div>
               </Link>
-            );
-          })}
-        </HistoryContentLayout>
+            </Div>
+            <HistoryContentLayout $flex="v_center_start" $width="100%">
+              {WikiHistoryListDummyData.map((elem) => {
+                return (
+                  <Link key={`${elem.idx}`} to={`./${elem.idx}`}>
+                    <li>{elem.content}</li>
+                  </Link>
+                );
+              })}
+            </HistoryContentLayout>
+          </Article>
+        </Section>
       </Article>
-    </Section>
+    </GameContentLayout>
   );
 };
 

--- a/src/page/GamePage.js
+++ b/src/page/GamePage.js
@@ -12,10 +12,6 @@ const PageWrapper = styled(Div)`
   min-height: 100vh;
   position: relative;
 `;
-// const FooterWrapper = styled(Div)`
-//   position: absolute;
-//   bottom: 0;
-// `;
 
 const GamePage = () => {
   return (

--- a/src/page/WikiHistoryContentPage.js
+++ b/src/page/WikiHistoryContentPage.js
@@ -12,10 +12,6 @@ const PageWrapper = styled(Div)`
   min-height: 100vh;
   position: relative;
 `;
-// const FooterWrapper = styled(Div)`
-//   position: absolute;
-//   bottom: 0;
-// `;
 
 const WikiHistoryContentPage = () => {
   return (

--- a/src/page/WikiHistoryContentPage.js
+++ b/src/page/WikiHistoryContentPage.js
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { styled } from "styled-components";
+import { Div, Section } from "../style/LayoutStyle";
+
+import HeaderItem from "../component/HeaderItem";
+import GameListContainer from "../container/GameListNavContainer";
+import FooterItem from "../component/FooterItem";
+import WikiHistoryContentContainer from "../container/inWikiComponent/WikiHistoryContentContainer";
+
+const PageWrapper = styled(Div)`
+  min-height: 100vh;
+  position: relative;
+`;
+// const FooterWrapper = styled(Div)`
+//   position: absolute;
+//   bottom: 0;
+// `;
+
+const WikiHistoryContentPage = () => {
+  return (
+    <PageWrapper>
+      <HeaderItem />
+      <GameListContainer />
+      <Section $flex="v_center_center" $margin="100px 0 0 0" $padding="0 60px" $width="100vw">
+        <WikiHistoryContentContainer />
+      </Section>
+      <FooterItem />
+    </PageWrapper>
+  );
+};
+
+export default WikiHistoryContentPage;

--- a/src/page/WikiHistoryPage.js
+++ b/src/page/WikiHistoryPage.js
@@ -12,10 +12,6 @@ const PageWrapper = styled(Div)`
   min-height: 100vh;
   position: relative;
 `;
-// const FooterWrapper = styled(Div)`
-//   position: absolute;
-//   bottom: 0;
-// `;
 
 const WikiHistoryPage = () => {
   return (

--- a/src/page/WikiHistoryPage.js
+++ b/src/page/WikiHistoryPage.js
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { styled } from "styled-components";
+import { Div, Section } from "../style/LayoutStyle";
+
+import HeaderItem from "../component/HeaderItem";
+import GameListContainer from "../container/GameListNavContainer";
+import FooterItem from "../component/FooterItem";
+import WikiHistoryListContainer from "../container/inWikiComponent/WikiHistoryListContainer";
+
+const PageWrapper = styled(Div)`
+  min-height: 100vh;
+  position: relative;
+`;
+// const FooterWrapper = styled(Div)`
+//   position: absolute;
+//   bottom: 0;
+// `;
+
+const WikiHistoryPage = () => {
+  return (
+    <PageWrapper>
+      <HeaderItem />
+      <GameListContainer />
+      <Section $flex="v_center_center" $margin="100px 0 0 0" $padding="0 60px" $width="100vw">
+        <WikiHistoryListContainer />
+      </Section>
+      <FooterItem />
+    </PageWrapper>
+  );
+};
+
+export default WikiHistoryPage;

--- a/src/style/ButtonStyle.js
+++ b/src/style/ButtonStyle.js
@@ -13,7 +13,6 @@ export const Button = styled.button`
   color: ${(props) => setColor(props.$color || "black")};
   font-size: ${(props) => setSize(props.$fontSize || "medium")};
   font-weight: ${(props) => setWeight(props.$fontWeight || "normal")};
-  border: ${(props) => props.$border || "none"};
-  border-style: ${(props) => props.$borderStyle || "none"};
+  border: ${(props) => props.$borderStyle || "none"};
   border-radius: ${(props) => props.$borderRadius || "0"};
 `;

--- a/src/util/ImgTextBtnUtil.js
+++ b/src/util/ImgTextBtnUtil.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Button } from "../style/ButtonStyle";
 import { Div } from "../style/LayoutStyle";
 import { Img } from "../style/ImgStyle";
+import { setColor } from "../style/SetStyle";
 
 const ImgTextBtnUtil = ({ img, text, color, backgroundColor, onClick }) => {
   return (
@@ -9,14 +10,14 @@ const ImgTextBtnUtil = ({ img, text, color, backgroundColor, onClick }) => {
       $flex="h_center_center"
       $backgroundColor={backgroundColor}
       $color={color}
-      $width="120px"
+      $padding="15px 20px"
       $height="50px"
       $fontWeight="bold"
       $borderRadius="20px"
-      $border={`1px solid ${color}`}
+      $borderStyle={`1px solid ${setColor(color)}`}
       onClick={onClick}
     >
-      <Div $margin="0 10px 0 0" $height="15px">
+      <Div $margin="0 10px 0 0" $height="25px">
         <Img src={img} alt={text} />
       </Div>
       {text}


### PR DESCRIPTION
GamePage에서 커뮤니티/위키 탭 클릭에 따라 하위 컨테이너 변경되는 것 외에

히스토리 버튼 클릭 시 WikiHistoryPage(WikiHistoryListContainer) 열림, 
WikiHistoryListContainer 내 리스트 클릭 시 WikiHistoryContentPage(WikiHistoryContentContainer) 열림, 
BACK 버튼 클릭 시 이전 페이지로 이동 
모두 페이지 이동(Link)으로 구현